### PR TITLE
Fix Serailizable error

### DIFF
--- a/src/Facebook/FacebookApp.php
+++ b/src/Facebook/FacebookApp.php
@@ -107,4 +107,28 @@ class FacebookApp implements \Serializable
 
         $this->__construct($id, $secret);
     }
+
+    /**
+     * Serializes the object to an array.
+     * 
+     * @return array
+     */
+    public function __serialize()
+    {
+        return [
+            'id' => $this->id,
+            'secret' => $this->secret,
+        ];
+    }
+
+    /**
+     * Restores the object state from an array.
+     * 
+     * @param array $data
+     */
+    public function __unserialize($data)
+    {
+        $this->id = $data['id'];
+        $this->secret = $data['secret'];
+    }
 }


### PR DESCRIPTION
Facebook\FacebookApp implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)